### PR TITLE
implemented copy and move assignment operators

### DIFF
--- a/include/boost/pimpl/auto_impl.hpp
+++ b/include/boost/pimpl/auto_impl.hpp
@@ -177,10 +177,15 @@ auto_object<Interface, SizeOfImplementation, AlignOfImplementation>::~auto_objec
 /// \brief Returns an implementation instance for an interface instance.
 ///
 ////////////////////////////////////////////////////////////////////////////////
-
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
 template <class Interface, std::uint32_t sz, std::uint8_t al> auto       & auto_object<Interface, sz, al>::impl()       noexcept { return reinterpret_cast<typename implementation<Interface>::type &>( storage ); }
 template <class Interface, std::uint32_t sz, std::uint8_t al> auto const & auto_object<Interface, sz, al>::impl() const noexcept { return const_cast<auto_object &>( *this ).impl(); } ///< \overload
-
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 ///

--- a/include/boost/pimpl/auto_impl.hpp
+++ b/include/boost/pimpl/auto_impl.hpp
@@ -97,6 +97,36 @@ auto_object<Interface, SizeOfImplementation, AlignOfImplementation>::auto_object
     new ( &storage ) impl_t( other.impl() );
 }
 
+// Move assign //////////////////////////////////////////////////////////////////
+template
+<
+    class Interface,
+    std::uint32_t SizeOfImplementation,
+    std::uint8_t  AlignOfImplementation
+>
+auto_object<Interface, SizeOfImplementation, AlignOfImplementation>& auto_object<Interface, SizeOfImplementation, AlignOfImplementation>::operator=( auto_object && other )
+{
+    if( this != &other ) {
+        impl() = std::move( other.impl() );
+    }
+    return *this;
+}
+
+// Copy assign //////////////////////////////////////////////////////////////////
+template
+<
+    class Interface,
+    std::uint32_t SizeOfImplementation,
+    std::uint8_t  AlignOfImplementation
+>
+auto_object<Interface, SizeOfImplementation, AlignOfImplementation>& auto_object<Interface, SizeOfImplementation, AlignOfImplementation>::operator=( auto_object const & other )
+{
+    if( this != &other ) {
+        impl() = other.impl() ;
+    }
+    return *this;
+}
+
 // Generic /////////////////////////////////////////////////////////////////////
 template
 <

--- a/include/boost/pimpl/auto_impl.hpp
+++ b/include/boost/pimpl/auto_impl.hpp
@@ -36,14 +36,13 @@ namespace pimpl
 
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// \struct implementation
+/// \class implementation
 ///
 /// \brief Interface -> implementation mapping metafunction.
 /// \details By default maps to the Interface::implementation member type. Can
 /// be specialized to use a different mapping.
 ///
 ////////////////////////////////////////////////////////////////////////////////
-
 template <class Interface>
 struct implementation { using type = typename Interface::implementation; };
 

--- a/include/boost/pimpl/auto_impl.hpp
+++ b/include/boost/pimpl/auto_impl.hpp
@@ -39,13 +39,13 @@ namespace pimpl
 /// \struct implementation
 ///
 /// \brief Interface -> implementation mapping metafunction.
-/// \details By default maps to the Interface::impl member type. Can be
-/// specialized to use a different mapping.
+/// \details By default maps to the Interface::implementation member type. Can
+/// be specialized to use a different mapping.
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
 template <class Interface>
-struct implementation { using type = typename Interface::impl; };
+struct implementation { using type = typename Interface::implementation; };
 
 
 namespace detail

--- a/include/boost/pimpl/auto_pimpl.hpp
+++ b/include/boost/pimpl/auto_pimpl.hpp
@@ -78,8 +78,21 @@ public:
     using pimpl_base = auto_object;
 
 protected:
-    /// \note MSVC's (tested@14.1) is_*_constructible type traits don't work
-    /// with incomplete types.
+    /// <VAR>Interface</VAR> has to explicitly declare its constructors,
+    /// destructor and assignment operators (if it uses/provides them) and their
+    /// respective exception specification or deleted status (otherwise
+    /// compilation fails here due to infinite template instantiation recursion)
+    /// - this is by design:
+    /// * to force API authors to write self-documenting interfaces
+    /// * to prevent the compiler from assuming all of the defaultable functions
+    /// (except the destructor) to be possibly throwing
+    /// * to enable terse/defaulted noexcept implementations (e.g.:
+    /// Impl::Impl( Impl && ) noexcept = default; instead of
+    /// Impl::Impl( Impl && other ) noexcept : pimpl_base( std::move( other )
+    /// {}).
+    ///
+    /// \note MSVC's (tested@14.1) is_*_constructible type traits do not work
+    /// here (with incomplete types).
     ///                                       (11.05.2017.) (Domagoj Saric)
     auto_object(                      ) noexcept( noexcept( Interface() ) );
     auto_object( auto_object       && ) noexcept( noexcept( Interface( Interface() ) ) );

--- a/include/boost/pimpl/auto_pimpl.hpp
+++ b/include/boost/pimpl/auto_pimpl.hpp
@@ -60,11 +60,16 @@ struct fwd {};
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
+#ifdef _MSC_VER
+#   pragma warning( push )
+#   pragma warning( disable : 4324 ) // Structure was padded due to alignment specifier.
+#endif // _MSC_VER
+
 template
 <
     class Interface,
     std::uint32_t SizeOfImplementation,
-    std::uint8_t  AlignOfImplementation
+    std::uint8_t  AlignOfImplementation = sizeof( void * )
 >
 class auto_object
 {
@@ -91,6 +96,10 @@ private:
     struct alignas( AlignOfImplementation ) storage_t { unsigned char raw_bytes[ SizeOfImplementation ]; };
     storage_t storage;
 }; // class auto_object
+
+#ifdef _MSC_VER
+#   pragma warning( pop )
+#endif // _MSC_VER
 
 //------------------------------------------------------------------------------
 } // namespace pimpl

--- a/include/boost/pimpl/auto_pimpl.hpp
+++ b/include/boost/pimpl/auto_pimpl.hpp
@@ -81,6 +81,8 @@ protected:
     template <typename ... Args>
     auto_object( fwd, Args && ...     );
    ~auto_object(                      ) noexcept;
+    auto_object& operator=( auto_object       && );
+    auto_object& operator=( auto_object const  & );
 
     auto       & impl()       noexcept;
     auto const & impl() const noexcept;


### PR DESCRIPTION
Added implementation of copy and move assignment operators.

Compiler deletes them because of user-specified move constructor. See [rule of five](http://en.cppreference.com/w/cpp/language/rule_of_three).